### PR TITLE
Fix footer not completing site

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -44,6 +44,6 @@
         window.location = e.currentTarget.href
         openAnchorAccordion();
       });
-    </script>`
+    </script>
   </body>
 </html>


### PR DESCRIPTION
A single quotation mark after <script> added multiple lines with whitespace so that the footer didn't complete the site correctly.

![2020-12-09 17_24_51-](https://user-images.githubusercontent.com/29982899/101656859-7da33580-3a43-11eb-95e9-f6cae4df6caf.png)
